### PR TITLE
Fix webpack import style

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { execSync } from "child_process";
+import webpack from "webpack";
 
 function getBuildInfo() {
   // Multi-environment git commit hash resolution
@@ -54,7 +55,6 @@ function getBuildInfo() {
 const nextConfig: NextConfig = {
   webpack: (config) => {
     // Define build info constants for webpack
-    const webpack = require('webpack');
     config.plugins.push(
       new webpack.DefinePlugin(getBuildInfo())
     );


### PR DESCRIPTION
## Summary
- use an ES module import for webpack in `next.config.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685021971ac483268ee6eaed27a88f4f